### PR TITLE
Tracking Database Schema

### DIFF
--- a/schema.psql
+++ b/schema.psql
@@ -1,0 +1,145 @@
+--
+-- PostgreSQL database dump
+--
+
+-- Dumped from database version 9.6.13
+-- Dumped by pg_dump version 9.6.13
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+--
+-- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: 
+--
+
+CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
+
+
+--
+-- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: 
+--
+
+COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
+
+
+SET default_tablespace = '';
+
+SET default_with_oids = false;
+
+--
+-- Name: beta_testers; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.beta_testers (
+    username character varying NOT NULL
+);
+
+
+ALTER TABLE public.beta_testers OWNER TO postgres;
+
+--
+-- Name: page_permissions; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.page_permissions (
+    user_id integer NOT NULL,
+    page_id integer NOT NULL,
+    is_owner boolean DEFAULT false NOT NULL,
+    can_edit boolean DEFAULT false NOT NULL,
+    user_encrypted_page_key bytea NOT NULL
+);
+
+
+ALTER TABLE public.page_permissions OWNER TO postgres;
+
+--
+-- Name: pages; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.pages (
+    id integer NOT NULL,
+    title bytea NOT NULL,
+    body bytea,
+    author_id integer NOT NULL,
+    version integer
+);
+
+
+ALTER TABLE public.pages OWNER TO postgres;
+
+--
+-- Name: user_activity; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.user_activity (
+    user_id integer NOT NULL,
+    url character varying NOT NULL,
+    "timestamp" timestamp without time zone NOT NULL
+);
+
+
+ALTER TABLE public.user_activity OWNER TO postgres;
+
+--
+-- Name: users; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    username character varying NOT NULL,
+    email character varying NOT NULL,
+    password_hash character varying NOT NULL,
+    main_key_encrypted bytea,
+    private_key_encrypted bytea,
+    public_key bytea,
+    salt bytea,
+    version integer
+);
+
+
+ALTER TABLE public.users OWNER TO postgres;
+
+--
+-- Name: pages pages_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.pages
+    ADD CONSTRAINT pages_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: users users_email_key; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.users
+    ADD CONSTRAINT users_email_key UNIQUE (email);
+
+
+--
+-- Name: users users_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.users
+    ADD CONSTRAINT users_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: users users_username_key; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.users
+    ADD CONSTRAINT users_username_key UNIQUE (username);
+
+
+--
+-- PostgreSQL database dump complete
+--
+


### PR DESCRIPTION
In an effort to track _everything_ related to the software in one place (and to hopefully make deployment easier), I've dumped the current database schema using the following command.

`pg_dump setonotes --schema-only -f schema.psql`

The output is tracked as a file in the root directory, though it could of course live anywhere. I propose that future changes to the database be tracked by running the above command (or similar) prior to merging. This will promote smooth deployments.