### PR TITLE
Update `blackfriday` dependency to use correct URL

### DIFF
--- a/cmd/handlers.go
+++ b/cmd/handlers.go
@@ -8,7 +8,7 @@ import (
 
     "github.com/setonotes/pkg/page"
 
-    "github.com/blackfriday"
+    "gopkg.in/russross/blackfriday.v2"
     "github.com/microcosm-cc/bluemonday"
 )
 


### PR DESCRIPTION
It turns out that `blackfriday` isn't hosted on github.com anymore, but instead on gopkg.in. (I mean, it _is_ hosted on Github, but the recommended pull location isn't.) See README here: https://github.com/russross/blackfriday#installation

This small PR corrects the import statement in `handlers.go` to point to the proper location. This affects old installations that haven't switched over to the new package location.

`blackfriday` as a dependency will become obsolete once server-side rendering is abolished, but for now we should make sure our dependencies are updated.